### PR TITLE
allow setting USERNAME, PASSWORD as envars or reading them from bitcoin.conf

### DIFF
--- a/runthenumbers.sh
+++ b/runthenumbers.sh
@@ -1,7 +1,14 @@
 #!/bin/bash
 
 
-CONF_FILE=~/.bitcoin/bitcoin.conf
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+	CONF_FILE=~/.bitcoin/bitcoin.conf
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+	CONF_FILE=~/Library/Application Support/Bitcoin/bitcoin.conf
+else
+	# lol
+	CONF_FILE=forgetit.conf
+fi
 
 if [ -f "$CONF_FILE" ]; then
     # Try to get the username and password from bitcoin.conf, if it exists in its default location


### PR DESCRIPTION
A minor enhancement. I prefer never to set credentials in files that are under source control, so I've added an option to pass them to the script as environment variables, and also made the script look them up in the default `bitcoin.conf` location.